### PR TITLE
Fix event editor data reuse bug (Issue #10)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -71,7 +71,7 @@ To run the application locally with Firebase emulators:
     -   Run an initial build of both packages.
     -   Start `tsc:watch` and `rollup:watch` for both frontend and backend to auto-rebuild on file changes.
     -   Start the Firebase emulators with imported test data and the `emulator` configuration injected via rollup.
-2.  Access the application at `http://localhost:5002/beatles`.
+2.  Access the application at `http://localhost:5002/test`.
 3.  Access the Emulator UI at `http://localhost:4000`.
 
 ### Login Flow

--- a/packages/frontend/src/components/app-main.ts
+++ b/packages/frontend/src/components/app-main.ts
@@ -25,9 +25,9 @@ import { CreateJoinRequest, db, getHostBand } from "../storage";
 import "./login-dialog";
 import "./band-schedule";
 import "./band-overview";
-import "./event-editor";
 import { EventEditor } from "./event-editor";
 import { repeat } from "lit/directives/repeat";
+import { BandEventFromDb } from "../model/bandevent";
 import { User } from "../datamodel";
 import { band } from "../model/band";
 import { ProfileEditor } from "./profile-editor";
@@ -305,6 +305,11 @@ export class AppMain extends LitElement {
     }
   }
 
+  addNewEvent() {
+    this.addDialogEditor.data = BandEventFromDb.empty();
+    this.addDialog.show();
+  }
+
   saveNewEvent(): void {
     const editor = this.addDialogEditor;
     console.log("[app-main] Editor:", editor);
@@ -575,7 +580,7 @@ export class AppMain extends LitElement {
           variant="primary"
           icon="add"
           style="border-radius: 9999px; padding: 16px; box-shadow: var(--app-shadow-lg);"
-          @click=${() => this.addDialog.show()}
+          @click=${() => this.addNewEvent()}
         ></app-button>
       </div>
       <app-dialog id="add-dialog" heading="Ny händelse" hideCloseButton>

--- a/packages/frontend/src/components/datetime-input.ts
+++ b/packages/frontend/src/components/datetime-input.ts
@@ -6,9 +6,6 @@ import "./time-range";
 
 @customElement("datetime-input")
 export class DatetimeInput extends LitElement {
-  @property({ type: String })
-  initial_value: string; // "2020-02-29T19:50" or "2020-02-29"
-
   @state()
   private _date: string = "";
 
@@ -27,14 +24,7 @@ export class DatetimeInput extends LitElement {
   @query("#time")
   time: AppInput;
 
-  willUpdate(changedProperties: Map<string, any>) {
-    if (changedProperties.has("initial_value") && this.initial_value) {
-      const [d, t] = this.initial_value.split("T");
-      this._date = d || "";
-      this._time = t || "";
-    }
-  }
-
+  @property({ type: String })
   get value() {
     if (this._date) {
       if (this._time) {

--- a/packages/frontend/src/components/event-editor.ts
+++ b/packages/frontend/src/components/event-editor.ts
@@ -2,7 +2,6 @@ import "./app-input";
 import "./app-button";
 import { AppInput } from "./app-input";
 import { css, html, LitElement } from "lit";
-import { ifDefined } from "lit/directives/if-defined.js";
 import "./datetime-input";
 import { DatetimeInput } from "./datetime-input";
 import { customElement, property, query } from "lit/decorators.js";
@@ -38,6 +37,12 @@ export class EventEditor extends LitElement {
 
   @query("#stop")
   stopInput: DatetimeInput;
+
+  willUpdate(changedProperties: Map<string, any>) {
+    if (changedProperties.has("data")) {
+      this.range = this.data.hasStopTime();
+    }
+  }
 
   deleteEvent() {
     if (confirm("Är du säker på att du vill ta bort den här händelsen? Detta går inte att ångra.")) {
@@ -77,7 +82,7 @@ export class EventEditor extends LitElement {
         type="text"
         required
         ?disabled=${isCancelled}
-        value="${this.data.type}"
+        .value="${this.data.type}"
         @input=${(e: CustomEvent) => { this.data.type = (e.target as AppInput).value; }}
       ></app-input>
       <app-input
@@ -85,7 +90,7 @@ export class EventEditor extends LitElement {
         id="location"
         type="text"
         ?disabled=${isCancelled}
-        value="${ifDefined(this.data.location)}"
+        .value="${this.data.location || ""}"
         @input=${(e: CustomEvent) => { this.data.location = (e.target as AppInput).value; }}
       ></app-input>
       <app-input
@@ -93,21 +98,21 @@ export class EventEditor extends LitElement {
         id="desc"
         multiline
         ?disabled=${isCancelled}
-        value="${ifDefined(this.data.description)}"
+        .value="${this.data.description || ""}"
         @input=${(e: CustomEvent) => { this.data.description = (e.target as AppInput).value; }}
       ></app-input>
       <datetime-input
         id="start"
         required
         ?disabled=${isCancelled}
-        initial_value="${ifDefined(this.data.start)}"
+        .value="${this.data.start || ""}"
       ></datetime-input>
       <span class="ranged">-</span>
       <datetime-input
         id="stop"
         class="ranged"
         ?disabled=${isCancelled}
-        initial_value="${ifDefined(this.data.stop)}"
+        .value="${this.data.stop || ""}"
       ></datetime-input>
       <app-button
         variant="icon"

--- a/packages/frontend/src/model/bandevent.ts
+++ b/packages/frontend/src/model/bandevent.ts
@@ -102,7 +102,7 @@ const BandEventConverter: FirestoreDataConverter<BandEvent> = {
 };
 
 // A band event.
-class BandEventFromDb implements BandEvent {
+export class BandEventFromDb implements BandEvent {
   constructor(
     public ref: BandEventReference,
     public type: string,
@@ -135,5 +135,9 @@ class BandEventFromDb implements BandEvent {
       this.description,
       this.cancelled
     );
+  }
+
+  static empty(): BandEvent {
+    return new BandEventFromDb(null, "", "", undefined, "", "", false);
   }
 }


### PR DESCRIPTION
This PR fixes a bug where the event editor would incorrectly persist data between editing an existing event and creating a new one.

Key changes:
- Reset DatetimeInput state when value is cleared.
- Use property bindings in EventEditor to ensure child inputs are always overwritten with fresh data.
- Explicitly reset the 'New Event' editor in AppMain with a clean BandEvent object before opening the dialog.
- Added a static empty() factory to the BandEvent model.
- Updated GEMINI.md with the correct local development test URL.